### PR TITLE
Fix module layout issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,34 @@
-mod reishi;
-use reishi::*;
+pub mod reishi;
 
 #[cfg(test)]
 mod tests {
     #[test]
     fn basic_token_test() {
-        let mut l = reishi::lexer::Lexer::new('.'.to_string());
+        let mut l = crate::reishi::lexer::Lexer::new('.'.to_string());
         let test_token = l.read_char();
-        assert_eq!(test_token.token_type, crate::reishi::token::TokenType::Period)
+        assert_eq!(
+            test_token.token_type,
+            crate::reishi::token::TokenType::Period
+        )
     }
     #[test]
     fn is_number_test() {
         let mut l = crate::reishi::lexer::Lexer::new('1'.to_string());
         let test_token = l.read_char();
-        assert_eq!(test_token.token_type, crate::reishi::token::TokenType::Number)
+        assert_eq!(
+            test_token.token_type,
+            crate::reishi::token::TokenType::Number
+        )
     }
 
     #[test]
     fn is_letter_test() {
         let mut l = crate::reishi::lexer::Lexer::new('c'.to_string());
         let test_token = l.read_char();
-        assert_eq!(test_token.token_type, crate::reishi::token::TokenType::Character)
+        assert_eq!(
+            test_token.token_type,
+            crate::reishi::token::TokenType::Character
+        )
     }
 
     #[test]
@@ -29,5 +37,4 @@ mod tests {
         let test_token = l.read_char();
         assert_eq!(test_token.token_place, 0)
     }
-
 }

--- a/src/reishi/mod.rs
+++ b/src/reishi/mod.rs
@@ -1,4 +1,2 @@
-pub mod token;
 pub mod lexer;
-pub use token::*;
-pub use lexer::*;
+pub mod token;


### PR DESCRIPTION
- Removed unnecessary `use`S.
- Made the `reishi` module public (this is not required to pass the tests, but good to allow it to be used from another crate, can change as per your needs).